### PR TITLE
Enforce ordered popping of jobs off the database queue

### DIFF
--- a/src/WP_Queue/Connections/DatabaseConnection.php
+++ b/src/WP_Queue/Connections/DatabaseConnection.php
@@ -68,7 +68,7 @@ class DatabaseConnection implements ConnectionInterface {
 			SELECT * FROM {$this->jobs_table}
 			WHERE reserved_at IS NULL
 			AND available_at <= %s
-			ORDER BY available_at
+			ORDER BY available_at, id
 			LIMIT 1
 		", $this->datetime() );
 


### PR DESCRIPTION
When jobs are run from the queue when using the database connection you would have thought it would be FIFO, however, as we only order by available_at, this consistency isn't kept. Adding an additional sort on id fixes this problem.